### PR TITLE
feat: add list artists screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
+    jacoco
 }
 
 android {
@@ -17,6 +18,9 @@ android {
     }
 
     buildTypes {
+        debug {
+            enableUnitTestCoverage = true
+        }
         release {
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
@@ -62,4 +66,24 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.contrib) {
         exclude(group = "org.checkerframework", module = "checker")
     }
+}
+
+tasks.register<JacocoReport>("jacocoTestReport") {
+    dependsOn("testDebugUnitTest")
+    reports {
+        xml.required.set(true)
+        html.required.set(true)
+    }
+    val fileFilter = listOf(
+        "**/R.class", "**/R\$*.class", "**/BuildConfig.*", "**/Manifest*.*",
+        "**/*Test*.*", "android/**/*.*", "**/databinding/**", "**/BR.class"
+    )
+    val debugTree = fileTree("${layout.buildDirectory.get()}/tmp/kotlin-classes/debug") {
+        exclude(fileFilter)
+    }
+    sourceDirectories.setFrom(files("${projectDir}/src/main/java"))
+    classDirectories.setFrom(files(debugTree))
+    executionData.setFrom(fileTree(layout.buildDirectory.get()) {
+        include("outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")
+    })
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
-    jacoco
 }
 
 android {
@@ -18,9 +17,6 @@ android {
     }
 
     buildTypes {
-        debug {
-            enableUnitTestCoverage = true
-        }
         release {
             isMinifyEnabled = false
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
@@ -66,24 +62,4 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.contrib) {
         exclude(group = "org.checkerframework", module = "checker")
     }
-}
-
-tasks.register<JacocoReport>("jacocoTestReport") {
-    dependsOn("testDebugUnitTest")
-    reports {
-        xml.required.set(true)
-        html.required.set(true)
-    }
-    val fileFilter = listOf(
-        "**/R.class", "**/R\$*.class", "**/BuildConfig.*", "**/Manifest*.*",
-        "**/*Test*.*", "android/**/*.*", "**/databinding/**", "**/BR.class"
-    )
-    val debugTree = fileTree("${layout.buildDirectory.get()}/tmp/kotlin-classes/debug") {
-        exclude(fileFilter)
-    }
-    sourceDirectories.setFrom(files("${projectDir}/src/main/java"))
-    classDirectories.setFrom(files(debugTree))
-    executionData.setFrom(fileTree(layout.buildDirectory.get()) {
-        include("outputs/unit_test_code_coverage/debugUnitTest/testDebugUnitTest.exec")
-    })
 }

--- a/app/src/androidTest/java/com/uniandes/appmoviles/vinilos/ArtistsListE2ETest.kt
+++ b/app/src/androidTest/java/com/uniandes/appmoviles/vinilos/ArtistsListE2ETest.kt
@@ -1,6 +1,7 @@
 package com.uniandes.appmoviles.vinilos
 
 import androidx.test.espresso.Espresso.onView
+import androidx.navigation.Navigation
 import androidx.test.espresso.IdlingRegistry
 import androidx.test.espresso.assertion.ViewAssertions.matches
 import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
@@ -25,8 +26,7 @@ class ArtistsListE2ETest {
     fun registerIdlingResource() {
         IdlingRegistry.getInstance().register(EspressoIdlingResource.countingIdlingResource)
         activityRule.scenario.onActivity { activity ->
-            androidx.navigation.Navigation
-                .findNavController(activity, R.id.nav_host_fragment)
+            Navigation.findNavController(activity, R.id.nav_host_fragment)
                 .navigate(R.id.artistsFragment)
         }
     }

--- a/app/src/androidTest/java/com/uniandes/appmoviles/vinilos/ArtistsListE2ETest.kt
+++ b/app/src/androidTest/java/com/uniandes/appmoviles/vinilos/ArtistsListE2ETest.kt
@@ -22,35 +22,30 @@ class ArtistsListE2ETest {
     val activityRule = ActivityScenarioRule(MainActivity::class.java)
 
     @Before
-    fun setup() {
+    fun registerIdlingResource() {
         IdlingRegistry.getInstance().register(EspressoIdlingResource.countingIdlingResource)
-        navigateToArtists()
-    }
-
-    @After
-    fun teardown() {
-        IdlingRegistry.getInstance().unregister(EspressoIdlingResource.countingIdlingResource)
-    }
-
-    private fun navigateToArtists() {
         activityRule.scenario.onActivity { activity ->
-            val navController = androidx.navigation.Navigation.findNavController(
-                activity, R.id.nav_host_fragment
-            )
-            navController.navigate(R.id.artistsFragment)
+            androidx.navigation.Navigation
+                .findNavController(activity, R.id.nav_host_fragment)
+                .navigate(R.id.artistsFragment)
         }
     }
 
-    @Test
-    fun progressBarIsGoneAfterLoad() {
-        onView(withId(R.id.progressBar))
-            .check(matches(not(isDisplayed())))
+    @After
+    fun unregisterIdlingResource() {
+        IdlingRegistry.getInstance().unregister(EspressoIdlingResource.countingIdlingResource)
     }
 
     @Test
-    fun swipeRefreshLayoutIsPresent() {
+    fun swipeRefreshIsDisplayed() {
         onView(withId(R.id.swipeRefresh))
             .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun progressBarIsHiddenAfterLoad() {
+        onView(withId(R.id.progressBar))
+            .check(matches(not(isDisplayed())))
     }
 
     @Test
@@ -62,7 +57,7 @@ class ArtistsListE2ETest {
     }
 
     @Test
-    fun recyclerIsHiddenWhenNoArtists() {
+    fun recyclerIsHiddenWhenListIsEmpty() {
         onView(withId(R.id.progressBar))
             .check(matches(not(isDisplayed())))
         onView(withId(R.id.recyclerArtists))

--- a/app/src/androidTest/java/com/uniandes/appmoviles/vinilos/ArtistsListE2ETest.kt
+++ b/app/src/androidTest/java/com/uniandes/appmoviles/vinilos/ArtistsListE2ETest.kt
@@ -1,0 +1,71 @@
+package com.uniandes.appmoviles.vinilos
+
+import androidx.test.espresso.Espresso.onView
+import androidx.test.espresso.IdlingRegistry
+import androidx.test.espresso.assertion.ViewAssertions.matches
+import androidx.test.espresso.matcher.ViewMatchers.isDisplayed
+import androidx.test.espresso.matcher.ViewMatchers.withId
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.uniandes.appmoviles.vinilos.network.EspressoIdlingResource
+import org.hamcrest.Matchers.not
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class ArtistsListE2ETest {
+
+    @get:Rule
+    val activityRule = ActivityScenarioRule(MainActivity::class.java)
+
+    @Before
+    fun setup() {
+        IdlingRegistry.getInstance().register(EspressoIdlingResource.countingIdlingResource)
+        navigateToArtists()
+    }
+
+    @After
+    fun teardown() {
+        IdlingRegistry.getInstance().unregister(EspressoIdlingResource.countingIdlingResource)
+    }
+
+    private fun navigateToArtists() {
+        activityRule.scenario.onActivity { activity ->
+            val navController = androidx.navigation.Navigation.findNavController(
+                activity, R.id.nav_host_fragment
+            )
+            navController.navigate(R.id.artistsFragment)
+        }
+    }
+
+    @Test
+    fun progressBarIsGoneAfterLoad() {
+        onView(withId(R.id.progressBar))
+            .check(matches(not(isDisplayed())))
+    }
+
+    @Test
+    fun swipeRefreshLayoutIsPresent() {
+        onView(withId(R.id.swipeRefresh))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun emptyViewIsShownWhenNoArtists() {
+        onView(withId(R.id.progressBar))
+            .check(matches(not(isDisplayed())))
+        onView(withId(R.id.emptyView))
+            .check(matches(isDisplayed()))
+    }
+
+    @Test
+    fun recyclerIsHiddenWhenNoArtists() {
+        onView(withId(R.id.progressBar))
+            .check(matches(not(isDisplayed())))
+        onView(withId(R.id.recyclerArtists))
+            .check(matches(not(isDisplayed())))
+    }
+}

--- a/app/src/main/java/com/uniandes/appmoviles/vinilos/MainActivity.kt
+++ b/app/src/main/java/com/uniandes/appmoviles/vinilos/MainActivity.kt
@@ -2,6 +2,10 @@ package com.uniandes.appmoviles.vinilos
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.navigation.fragment.NavHostFragment
+import androidx.navigation.ui.AppBarConfiguration
+import androidx.navigation.ui.NavigationUI
+import androidx.navigation.ui.setupWithNavController
 import com.uniandes.appmoviles.vinilos.databinding.ActivityMainBinding
 
 class MainActivity : AppCompatActivity() {
@@ -12,5 +16,23 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
+
+        setSupportActionBar(binding.toolbar)
+
+        val navHost = supportFragmentManager
+            .findFragmentById(R.id.nav_host_fragment) as NavHostFragment
+        val navController = navHost.navController
+
+        val appBarConfig = AppBarConfiguration(
+            setOf(R.id.albumsFragment, R.id.artistsFragment)
+        )
+        NavigationUI.setupActionBarWithNavController(this, navController, appBarConfig)
+        binding.bottomNav.setupWithNavController(navController)
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        val navHost = supportFragmentManager
+            .findFragmentById(R.id.nav_host_fragment) as NavHostFragment
+        return navHost.navController.navigateUp() || super.onSupportNavigateUp()
     }
 }

--- a/app/src/main/java/com/uniandes/appmoviles/vinilos/model/Artist.kt
+++ b/app/src/main/java/com/uniandes/appmoviles/vinilos/model/Artist.kt
@@ -1,0 +1,9 @@
+package com.uniandes.appmoviles.vinilos.model
+
+data class Artist(
+    val artistId: Int,
+    val name: String,
+    val image: String,
+    val description: String,
+    val birthDate: String
+)

--- a/app/src/main/java/com/uniandes/appmoviles/vinilos/network/NetworkServiceAdapter.kt
+++ b/app/src/main/java/com/uniandes/appmoviles/vinilos/network/NetworkServiceAdapter.kt
@@ -9,6 +9,7 @@ import com.android.volley.toolbox.JsonArrayRequest
 import com.android.volley.toolbox.JsonObjectRequest
 import com.android.volley.toolbox.Volley
 import com.uniandes.appmoviles.vinilos.model.Album
+import com.uniandes.appmoviles.vinilos.model.Artist
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -73,6 +74,48 @@ class NetworkServiceAdapter(context: Context) {
             }
         )
         requestQueue.add(request)
+    }
+
+    fun getArtists(
+        onComplete: (List<Artist>) -> Unit,
+        onError: (Exception) -> Unit
+    ) {
+        val url = "$BASE_URL/musicians"
+        EspressoIdlingResource.increment()
+        val request = JsonArrayRequest(
+            Request.Method.GET, url, null,
+            { response ->
+                EspressoIdlingResource.decrement()
+                onComplete(parseArtists(response))
+            },
+            { error ->
+                EspressoIdlingResource.decrement()
+                onError(mapVolleyError(error))
+            }
+        )
+        requestQueue.add(request)
+    }
+
+    private fun parseArtists(response: JSONArray): List<Artist> {
+        val artists = mutableListOf<Artist>()
+        for (i in 0 until response.length()) {
+            try {
+                artists.add(parseArtist(response.getJSONObject(i)))
+            } catch (_: Exception) {
+                // skip malformed items
+            }
+        }
+        return artists
+    }
+
+    private fun parseArtist(obj: JSONObject): Artist {
+        return Artist(
+            artistId = obj.optInt("id", 0),
+            name = obj.optString("name", ""),
+            image = obj.optString("image", ""),
+            description = obj.optString("description", ""),
+            birthDate = obj.optString("birthDate", "")
+        )
     }
 
     private fun parseAlbums(response: JSONArray): List<Album> {

--- a/app/src/main/java/com/uniandes/appmoviles/vinilos/network/NetworkServiceAdapter.kt
+++ b/app/src/main/java/com/uniandes/appmoviles/vinilos/network/NetworkServiceAdapter.kt
@@ -21,7 +21,7 @@ class NetworkServiceAdapter(context: Context) {
 
     companion object {
         private var instance: NetworkServiceAdapter? = null
-        private const val BASE_URL = "https://mobile-app-vinilos-a848950b5db4.herokuapp.com"
+        private const val BASE_URL = "https://backvynils-q6yc.onrender.com"
 
         fun getInstance(context: Context): NetworkServiceAdapter {
             return instance ?: synchronized(this) {

--- a/app/src/main/java/com/uniandes/appmoviles/vinilos/network/NetworkServiceAdapter.kt
+++ b/app/src/main/java/com/uniandes/appmoviles/vinilos/network/NetworkServiceAdapter.kt
@@ -21,7 +21,7 @@ class NetworkServiceAdapter(context: Context) {
 
     companion object {
         private var instance: NetworkServiceAdapter? = null
-        private const val BASE_URL = "https://backvynils-q6yc.onrender.com"
+        private const val BASE_URL = "https://mobile-app-vinilos-a848950b5db4.herokuapp.com"
 
         fun getInstance(context: Context): NetworkServiceAdapter {
             return instance ?: synchronized(this) {

--- a/app/src/main/java/com/uniandes/appmoviles/vinilos/network/NetworkServiceAdapter.kt
+++ b/app/src/main/java/com/uniandes/appmoviles/vinilos/network/NetworkServiceAdapter.kt
@@ -101,9 +101,7 @@ class NetworkServiceAdapter(context: Context) {
         for (i in 0 until response.length()) {
             try {
                 artists.add(parseArtist(response.getJSONObject(i)))
-            } catch (_: Exception) {
-                // skip malformed items
-            }
+            } catch (_: Exception) { }
         }
         return artists
     }
@@ -123,9 +121,7 @@ class NetworkServiceAdapter(context: Context) {
         for (i in 0 until response.length()) {
             try {
                 albums.add(parseAlbum(response.getJSONObject(i)))
-            } catch (_: Exception) {
-                // skip malformed items
-            }
+            } catch (_: Exception) { }
         }
         return albums
     }

--- a/app/src/main/java/com/uniandes/appmoviles/vinilos/repository/impl/ArtistRepositoryImpl.kt
+++ b/app/src/main/java/com/uniandes/appmoviles/vinilos/repository/impl/ArtistRepositoryImpl.kt
@@ -1,0 +1,15 @@
+package com.uniandes.appmoviles.vinilos.repository.impl
+
+import android.content.Context
+import com.uniandes.appmoviles.vinilos.model.Artist
+import com.uniandes.appmoviles.vinilos.network.NetworkServiceAdapter
+import com.uniandes.appmoviles.vinilos.repository.interfaces.ArtistRepository
+
+class ArtistRepositoryImpl(private val context: Context) : ArtistRepository {
+
+    private val networkAdapter = NetworkServiceAdapter.getInstance(context)
+
+    override fun getArtists(onComplete: (List<Artist>) -> Unit, onError: (Exception) -> Unit) {
+        networkAdapter.getArtists(onComplete, onError)
+    }
+}

--- a/app/src/main/java/com/uniandes/appmoviles/vinilos/repository/interfaces/ArtistRepository.kt
+++ b/app/src/main/java/com/uniandes/appmoviles/vinilos/repository/interfaces/ArtistRepository.kt
@@ -1,0 +1,7 @@
+package com.uniandes.appmoviles.vinilos.repository.interfaces
+
+import com.uniandes.appmoviles.vinilos.model.Artist
+
+interface ArtistRepository {
+    fun getArtists(onComplete: (List<Artist>) -> Unit, onError: (Exception) -> Unit)
+}

--- a/app/src/main/java/com/uniandes/appmoviles/vinilos/ui/artists/ArtistAdapter.kt
+++ b/app/src/main/java/com/uniandes/appmoviles/vinilos/ui/artists/ArtistAdapter.kt
@@ -5,6 +5,7 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
+import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
 import com.uniandes.appmoviles.vinilos.R
 import com.uniandes.appmoviles.vinilos.databinding.ItemArtistBinding
 import com.uniandes.appmoviles.vinilos.model.Artist
@@ -43,7 +44,7 @@ class ArtistAdapter :
                 .load(artist.image)
                 .placeholder(R.drawable.ic_launcher_background)
                 .error(R.drawable.ic_launcher_background)
-                .transition(com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions.withCrossFade())
+                .transition(DrawableTransitionOptions.withCrossFade())
                 .into(binding.artistImage)
         }
     }

--- a/app/src/main/java/com/uniandes/appmoviles/vinilos/ui/artists/ArtistAdapter.kt
+++ b/app/src/main/java/com/uniandes/appmoviles/vinilos/ui/artists/ArtistAdapter.kt
@@ -1,0 +1,76 @@
+package com.uniandes.appmoviles.vinilos.ui.artists
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import com.uniandes.appmoviles.vinilos.R
+import com.uniandes.appmoviles.vinilos.databinding.ItemArtistBinding
+import com.uniandes.appmoviles.vinilos.model.Artist
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+class ArtistAdapter :
+    RecyclerView.Adapter<ArtistAdapter.ArtistViewHolder>() {
+
+    private var artists = listOf<Artist>()
+
+    fun updateArtists(newArtists: List<Artist>) {
+        val diff = DiffUtil.calculateDiff(ArtistDiffCallback(artists, newArtists))
+        artists = newArtists
+        diff.dispatchUpdatesTo(this)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ArtistViewHolder {
+        val binding = ItemArtistBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ArtistViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ArtistViewHolder, position: Int) {
+        holder.bind(artists[position])
+    }
+
+    override fun getItemCount() = artists.size
+
+    inner class ArtistViewHolder(private val binding: ItemArtistBinding) :
+        RecyclerView.ViewHolder(binding.root) {
+
+        fun bind(artist: Artist) {
+            binding.artistName.text = artist.name
+            binding.artistBirthDate.text = formatDate(artist.birthDate)
+            Glide.with(binding.root.context)
+                .load(artist.image)
+                .placeholder(R.drawable.ic_launcher_background)
+                .error(R.drawable.ic_launcher_background)
+                .transition(com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions.withCrossFade())
+                .into(binding.artistImage)
+        }
+    }
+
+    private fun formatDate(isoDate: String): String {
+        return try {
+            val inputFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault())
+            val outputFormat = SimpleDateFormat("d MMM. yyyy", Locale("es", "CO"))
+            val date = inputFormat.parse(isoDate) ?: return isoDate
+            outputFormat.format(date)
+        } catch (_: Exception) {
+            isoDate
+        }
+    }
+
+    private class ArtistDiffCallback(
+        private val oldList: List<Artist>,
+        private val newList: List<Artist>
+    ) : DiffUtil.Callback() {
+
+        override fun getOldListSize() = oldList.size
+        override fun getNewListSize() = newList.size
+
+        override fun areItemsTheSame(oldPos: Int, newPos: Int) =
+            oldList[oldPos].artistId == newList[newPos].artistId
+
+        override fun areContentsTheSame(oldPos: Int, newPos: Int) =
+            oldList[oldPos] == newList[newPos]
+    }
+}

--- a/app/src/main/java/com/uniandes/appmoviles/vinilos/ui/artists/ArtistsFragment.kt
+++ b/app/src/main/java/com/uniandes/appmoviles/vinilos/ui/artists/ArtistsFragment.kt
@@ -1,0 +1,71 @@
+package com.uniandes.appmoviles.vinilos.ui.artists
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import androidx.recyclerview.widget.GridLayoutManager
+import com.google.android.material.snackbar.Snackbar
+import com.uniandes.appmoviles.vinilos.R
+import com.uniandes.appmoviles.vinilos.databinding.FragmentArtistsBinding
+
+class ArtistsFragment : Fragment() {
+
+    private var _binding: FragmentArtistsBinding? = null
+    private val binding get() = _binding!!
+    private lateinit var viewModel: ArtistsViewModel
+    private lateinit var adapter: ArtistAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentArtistsBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        viewModel = ViewModelProvider(this)[ArtistsViewModel::class.java]
+
+        adapter = ArtistAdapter()
+
+        binding.recyclerArtists.layoutManager = GridLayoutManager(requireContext(), 2)
+        binding.recyclerArtists.adapter = adapter
+
+        binding.swipeRefresh.setOnRefreshListener {
+            viewModel.fetchArtists()
+        }
+
+        observeViewModel()
+        viewModel.fetchArtists()
+    }
+
+    private fun observeViewModel() {
+        viewModel.artists.observe(viewLifecycleOwner) { artists ->
+            adapter.updateArtists(artists)
+            binding.emptyView.visibility = if (artists.isEmpty()) View.VISIBLE else View.GONE
+            binding.recyclerArtists.visibility = if (artists.isEmpty()) View.GONE else View.VISIBLE
+        }
+        viewModel.isLoading.observe(viewLifecycleOwner) { isLoading ->
+            binding.progressBar.visibility = if (isLoading) View.VISIBLE else View.GONE
+            if (!isLoading) binding.swipeRefresh.isRefreshing = false
+        }
+        viewModel.error.observe(viewLifecycleOwner) { errorMsg ->
+            if (!errorMsg.isNullOrBlank()) {
+                Snackbar.make(binding.root, errorMsg, Snackbar.LENGTH_LONG)
+                    .setAction(R.string.retry) { viewModel.fetchArtists() }
+                    .show()
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/uniandes/appmoviles/vinilos/ui/artists/ArtistsFragment.kt
+++ b/app/src/main/java/com/uniandes/appmoviles/vinilos/ui/artists/ArtistsFragment.kt
@@ -48,8 +48,9 @@ class ArtistsFragment : Fragment() {
     private fun observeViewModel() {
         viewModel.artists.observe(viewLifecycleOwner) { artists ->
             adapter.updateArtists(artists)
-            binding.emptyView.visibility = if (artists.isEmpty()) View.VISIBLE else View.GONE
-            binding.recyclerArtists.visibility = if (artists.isEmpty()) View.GONE else View.VISIBLE
+            val hasError = !viewModel.error.value.isNullOrBlank()
+            binding.emptyView.visibility = if (artists.isEmpty() && !hasError) View.VISIBLE else View.GONE
+            binding.recyclerArtists.visibility = if (artists.isNotEmpty()) View.VISIBLE else View.GONE
         }
         viewModel.isLoading.observe(viewLifecycleOwner) { isLoading ->
             binding.progressBar.visibility = if (isLoading) View.VISIBLE else View.GONE
@@ -57,6 +58,7 @@ class ArtistsFragment : Fragment() {
         }
         viewModel.error.observe(viewLifecycleOwner) { errorMsg ->
             if (!errorMsg.isNullOrBlank()) {
+                binding.emptyView.visibility = View.GONE
                 Snackbar.make(binding.root, errorMsg, Snackbar.LENGTH_LONG)
                     .setAction(R.string.retry) { viewModel.fetchArtists() }
                     .show()

--- a/app/src/main/java/com/uniandes/appmoviles/vinilos/ui/artists/ArtistsViewModel.kt
+++ b/app/src/main/java/com/uniandes/appmoviles/vinilos/ui/artists/ArtistsViewModel.kt
@@ -1,0 +1,38 @@
+package com.uniandes.appmoviles.vinilos.ui.artists
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.uniandes.appmoviles.vinilos.model.Artist
+import com.uniandes.appmoviles.vinilos.repository.impl.ArtistRepositoryImpl
+
+class ArtistsViewModel(application: Application) : AndroidViewModel(application) {
+
+    private val repository = ArtistRepositoryImpl(application)
+
+    private val _artists = MutableLiveData<List<Artist>>(emptyList())
+    val artists: LiveData<List<Artist>> get() = _artists
+
+    private val _isLoading = MutableLiveData<Boolean>()
+    val isLoading: LiveData<Boolean> get() = _isLoading
+
+    private val _error = MutableLiveData<String?>()
+    val error: LiveData<String?> get() = _error
+
+    fun fetchArtists() {
+        if (_isLoading.value == true) return
+        _error.value = null
+        _isLoading.value = true
+        repository.getArtists(
+            onComplete = { artists ->
+                _artists.postValue(artists)
+                _isLoading.postValue(false)
+            },
+            onError = { exception ->
+                _error.postValue(exception.message)
+                _isLoading.postValue(false)
+            }
+        )
+    }
+}

--- a/app/src/main/res/color/bottom_nav_colors.xml
+++ b/app/src/main/res/color/bottom_nav_colors.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/white" android:state_checked="true" />
+    <item android:color="@color/md_theme_primary_container" />
+</selector>

--- a/app/src/main/res/drawable/ic_albums.xml
+++ b/app/src/main/res/drawable/ic_albums.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,2A10,10 0 0,0 2,12A10,10 0 0,0 12,22A10,10 0 0,0 22,12A10,10 0 0,0 12,2M12,4A8,8 0 0,1 20,12A8,8 0 0,1 12,20A8,8 0 0,1 4,12A8,8 0 0,1 12,4M12,9A3,3 0 0,0 9,12A3,3 0 0,0 12,15A3,3 0 0,0 15,12A3,3 0 0,0 12,9M12,11A1,1 0 0,1 13,12A1,1 0 0,1 12,13A1,1 0 0,1 11,12A1,1 0 0,1 12,11Z" />
+</vector>

--- a/app/src/main/res/drawable/ic_artists.xml
+++ b/app/src/main/res/drawable/ic_artists.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,4A4,4 0 0,1 16,8A4,4 0 0,1 12,12A4,4 0 0,1 8,8A4,4 0 0,1 12,4M12,14C16.42,14 20,15.79 20,18V20H4V18C4,15.79 7.58,14 12,14Z" />
+</vector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,20 +1,44 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar">
+
+        <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@color/md_theme_primary"
+            android:elevation="4dp"
+            app:titleTextColor="@color/white"
+            app:subtitleTextColor="@color/md_theme_primary_container" />
+
+    </com.google.android.material.appbar.AppBarLayout>
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/nav_host_fragment"
         android:name="androidx.navigation.fragment.NavHostFragment"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:layout_weight="1"
         app:defaultNavHost="true"
-        app:navGraph="@navigation/nav_graph"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:navGraph="@navigation/nav_graph" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+    <com.google.android.material.bottomnavigation.BottomNavigationView
+        android:id="@+id/bottom_nav"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/md_theme_primary"
+        app:itemIconTint="@color/bottom_nav_colors"
+        app:itemTextColor="@color/bottom_nav_colors"
+        app:menu="@menu/bottom_nav_menu"
+        app:labelVisibilityMode="labeled" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/fragment_artists.xml
+++ b/app/src/main/res/layout/fragment_artists.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/swipeRefresh"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerArtists"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/emptyView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/empty_artists"
+            android:textSize="16sp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>

--- a/app/src/main/res/layout/item_artist.xml
+++ b/app/src/main/res/layout/item_artist.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    app:cardCornerRadius="8dp"
+    app:cardElevation="4dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <ImageView
+            android:id="@+id/artistImage"
+            android:layout_width="match_parent"
+            android:layout_height="160dp"
+            android:scaleType="centerCrop"
+            android:contentDescription="@string/artist_image" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="8dp">
+
+            <TextView
+                android:id="@+id/artistName"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="14sp"
+                android:textStyle="bold"
+                android:textColor="@color/black"
+                android:maxLines="2"
+                android:ellipsize="end" />
+
+            <TextView
+                android:id="@+id/artistBirthDate"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="11sp"
+                android:textColor="@color/black"
+                android:layout_marginTop="2dp"
+                android:maxLines="1"
+                android:ellipsize="end" />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/app/src/main/res/menu/bottom_nav_menu.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:id="@+id/albumsFragment"
+        android:icon="@drawable/ic_albums"
+        android:title="@string/nav_albums" />
+
+    <item
+        android:id="@+id/artistsFragment"
+        android:icon="@drawable/ic_artists"
+        android:title="@string/nav_artists" />
+
+</menu>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -27,4 +27,11 @@
             android:defaultValue="0" />
     </fragment>
 
+
+    <fragment
+        android:id="@+id/artistsFragment"
+        android:name="com.uniandes.appmoviles.vinilos.ui.artists.ArtistsFragment"
+        android:label="Artistas"
+        tools:layout="@layout/fragment_artists" />
+
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,4 +7,6 @@
     <string name="label_description">Descripción</string>
     <string name="empty_albums">No hay álbumes disponibles</string>
     <string name="retry">Reintentar</string>
+    <string name="artist_image">Foto del artista</string>
+    <string name="empty_artists">No hay artistas disponibles</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,4 +9,6 @@
     <string name="retry">Reintentar</string>
     <string name="artist_image">Foto del artista</string>
     <string name="empty_artists">No hay artistas disponibles</string>
+    <string name="nav_albums">Álbumes</string>
+    <string name="nav_artists">Artistas</string>
 </resources>

--- a/app/src/test/java/com/uniandes/appmoviles/vinilos/ArtistsViewModelTest.kt
+++ b/app/src/test/java/com/uniandes/appmoviles/vinilos/ArtistsViewModelTest.kt
@@ -1,0 +1,144 @@
+package com.uniandes.appmoviles.vinilos
+
+import com.uniandes.appmoviles.vinilos.model.Artist
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+class ArtistsViewModelTest {
+
+    // --- Modelo Artist ---
+
+    @Test
+    fun `artist data class holds expected values`() {
+        val artist = makeArtist(id = 1, name = "Rubén Blades")
+        assertEquals(1, artist.artistId)
+        assertEquals("Rubén Blades", artist.name)
+        assertEquals("Cantante y actor panameño", artist.description)
+    }
+
+    @Test
+    fun `two artists with same data are equal`() {
+        val a = makeArtist(id = 5, name = "Carlos Vives")
+        val b = makeArtist(id = 5, name = "Carlos Vives")
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `two artists with different id are not equal`() {
+        val a = makeArtist(id = 1, name = "Carlos Vives")
+        val b = makeArtist(id = 2, name = "Carlos Vives")
+        assertNotEquals(a, b)
+    }
+
+    @Test
+    fun `artist with different name are not equal`() {
+        val a = makeArtist(id = 1, name = "Carlos Vives")
+        val b = makeArtist(id = 1, name = "Shakira")
+        assertNotEquals(a, b)
+    }
+
+    // --- Formateo de fecha ---
+
+    @Test
+    fun `formatDate returns readable string for valid ISO date`() {
+        val result = formatDate("1948-07-16T05:00:00.000Z")
+        assertEquals("16 jul. 1948", result)
+    }
+
+    @Test
+    fun `formatDate returns original string for invalid date`() {
+        val input = "not-a-date"
+        val result = formatDate(input)
+        assertEquals(input, result)
+    }
+
+    @Test
+    fun `formatDate handles empty string`() {
+        val result = formatDate("")
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `formatDate handles december correctly`() {
+        val result = formatDate("1990-12-01T00:00:00.000Z")
+        assertEquals("1 dic. 1990", result)
+    }
+
+    // --- Validaciones de lista ---
+
+    @Test
+    fun `all artist IDs in list are positive`() {
+        val artists = listOf(
+            makeArtist(id = 1, name = "Artista A"),
+            makeArtist(id = 2, name = "Artista B"),
+            makeArtist(id = 10, name = "Artista C")
+        )
+        assertTrue(artists.all { it.artistId > 0 })
+    }
+
+    @Test
+    fun `no artist has empty name`() {
+        val artists = listOf(
+            makeArtist(id = 1, name = "Rubén Blades"),
+            makeArtist(id = 2, name = "Carlos Vives")
+        )
+        assertFalse(artists.any { it.name.isBlank() })
+    }
+
+    @Test
+    fun `empty list has size zero`() {
+        val artists = emptyList<Artist>()
+        assertEquals(0, artists.size)
+    }
+
+    @Test
+    fun `artist list can be filtered by name`() {
+        val artists = listOf(
+            makeArtist(id = 1, name = "Rubén Blades"),
+            makeArtist(id = 2, name = "Carlos Vives"),
+            makeArtist(id = 3, name = "Shakira")
+        )
+        val filtered = artists.filter { it.name.contains("Carlos") }
+        assertEquals(1, filtered.size)
+        assertEquals("Carlos Vives", filtered.first().name)
+    }
+
+    @Test
+    fun `artist list sorted by name is alphabetical`() {
+        val artists = listOf(
+            makeArtist(id = 2, name = "Shakira"),
+            makeArtist(id = 1, name = "Carlos Vives"),
+            makeArtist(id = 3, name = "Rubén Blades")
+        )
+        val sorted = artists.sortedBy { it.name }
+        assertEquals("Carlos Vives", sorted[0].name)
+        assertEquals("Rubén Blades", sorted[1].name)
+        assertEquals("Shakira", sorted[2].name)
+    }
+
+    // --- Helpers ---
+
+    private fun makeArtist(id: Int, name: String) = Artist(
+        artistId = id,
+        name = name,
+        image = "https://example.com/photo.jpg",
+        description = "Cantante y actor panameño",
+        birthDate = "1948-07-16T05:00:00.000Z"
+    )
+
+    private fun formatDate(isoDate: String): String {
+        return try {
+            val inputFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.getDefault())
+            val outputFormat = SimpleDateFormat("d MMM. yyyy", Locale("es", "CO"))
+            val date = inputFormat.parse(isoDate) ?: return isoDate
+            outputFormat.format(date)
+        } catch (_: Exception) {
+            isoDate
+        }
+    }
+}

--- a/app/src/test/java/com/uniandes/appmoviles/vinilos/ArtistsViewModelTest.kt
+++ b/app/src/test/java/com/uniandes/appmoviles/vinilos/ArtistsViewModelTest.kt
@@ -4,6 +4,7 @@ import com.uniandes.appmoviles.vinilos.model.Artist
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.text.SimpleDateFormat
@@ -11,123 +12,157 @@ import java.util.Locale
 
 class ArtistsViewModelTest {
 
-    // --- Modelo Artist ---
-
     @Test
-    fun `artist data class holds expected values`() {
+    fun `artist stores correct values`() {
         val artist = makeArtist(id = 1, name = "Rubén Blades")
         assertEquals(1, artist.artistId)
         assertEquals("Rubén Blades", artist.name)
-        assertEquals("Cantante y actor panameño", artist.description)
+        assertEquals("Cantante panameño", artist.description)
     }
 
     @Test
-    fun `two artists with same data are equal`() {
-        val a = makeArtist(id = 5, name = "Carlos Vives")
-        val b = makeArtist(id = 5, name = "Carlos Vives")
-        assertEquals(a, b)
+    fun `artists with same data are equal`() {
+        assertEquals(makeArtist(id = 5, name = "Carlos Vives"), makeArtist(id = 5, name = "Carlos Vives"))
     }
 
     @Test
-    fun `two artists with different id are not equal`() {
-        val a = makeArtist(id = 1, name = "Carlos Vives")
-        val b = makeArtist(id = 2, name = "Carlos Vives")
-        assertNotEquals(a, b)
+    fun `artists with different id are not equal`() {
+        assertNotEquals(makeArtist(id = 1, name = "Carlos Vives"), makeArtist(id = 2, name = "Carlos Vives"))
     }
 
     @Test
-    fun `artist with different name are not equal`() {
-        val a = makeArtist(id = 1, name = "Carlos Vives")
-        val b = makeArtist(id = 1, name = "Shakira")
-        assertNotEquals(a, b)
-    }
-
-    // --- Formateo de fecha ---
-
-    @Test
-    fun `formatDate returns readable string for valid ISO date`() {
-        val result = formatDate("1948-07-16T05:00:00.000Z")
-        assertEquals("16 jul. 1948", result)
+    fun `artists with different name are not equal`() {
+        assertNotEquals(makeArtist(id = 1, name = "Carlos Vives"), makeArtist(id = 1, name = "Shakira"))
     }
 
     @Test
-    fun `formatDate returns original string for invalid date`() {
-        val input = "not-a-date"
-        val result = formatDate(input)
-        assertEquals(input, result)
+    fun `formatDate parses ISO date to readable format`() {
+        assertEquals("16 jul. 1948", formatDate("1948-07-16T05:00:00.000Z"))
     }
 
     @Test
-    fun `formatDate handles empty string`() {
-        val result = formatDate("")
-        assertEquals("", result)
+    fun `formatDate returns original value when input is invalid`() {
+        val bad = "not-a-date"
+        assertEquals(bad, formatDate(bad))
     }
 
     @Test
-    fun `formatDate handles december correctly`() {
-        val result = formatDate("1990-12-01T00:00:00.000Z")
-        assertEquals("1 dic. 1990", result)
+    fun `formatDate returns empty string when input is empty`() {
+        assertEquals("", formatDate(""))
     }
 
-    // --- Validaciones de lista ---
+    @Test
+    fun `formatDate handles december`() {
+        assertEquals("1 dic. 1990", formatDate("1990-12-01T00:00:00.000Z"))
+    }
 
     @Test
-    fun `all artist IDs in list are positive`() {
-        val artists = listOf(
-            makeArtist(id = 1, name = "Artista A"),
-            makeArtist(id = 2, name = "Artista B"),
-            makeArtist(id = 10, name = "Artista C")
+    fun `all artists in list have positive id`() {
+        val list = listOf(makeArtist(1, "A"), makeArtist(2, "B"), makeArtist(10, "C"))
+        assertTrue(list.all { it.artistId > 0 })
+    }
+
+    @Test
+    fun `no artist in list has blank name`() {
+        val list = listOf(makeArtist(1, "Rubén Blades"), makeArtist(2, "Carlos Vives"))
+        assertFalse(list.any { it.name.isBlank() })
+    }
+
+    @Test
+    fun `filter by name returns correct result`() {
+        val list = listOf(
+            makeArtist(1, "Rubén Blades"),
+            makeArtist(2, "Carlos Vives"),
+            makeArtist(3, "Shakira")
         )
-        assertTrue(artists.all { it.artistId > 0 })
+        val result = list.filter { it.name.contains("Carlos") }
+        assertEquals(1, result.size)
+        assertEquals("Carlos Vives", result.first().name)
     }
 
     @Test
-    fun `no artist has empty name`() {
-        val artists = listOf(
-            makeArtist(id = 1, name = "Rubén Blades"),
-            makeArtist(id = 2, name = "Carlos Vives")
-        )
-        assertFalse(artists.any { it.name.isBlank() })
-    }
-
-    @Test
-    fun `empty list has size zero`() {
-        val artists = emptyList<Artist>()
-        assertEquals(0, artists.size)
-    }
-
-    @Test
-    fun `artist list can be filtered by name`() {
-        val artists = listOf(
-            makeArtist(id = 1, name = "Rubén Blades"),
-            makeArtist(id = 2, name = "Carlos Vives"),
-            makeArtist(id = 3, name = "Shakira")
-        )
-        val filtered = artists.filter { it.name.contains("Carlos") }
-        assertEquals(1, filtered.size)
-        assertEquals("Carlos Vives", filtered.first().name)
-    }
-
-    @Test
-    fun `artist list sorted by name is alphabetical`() {
-        val artists = listOf(
-            makeArtist(id = 2, name = "Shakira"),
-            makeArtist(id = 1, name = "Carlos Vives"),
-            makeArtist(id = 3, name = "Rubén Blades")
-        )
-        val sorted = artists.sortedBy { it.name }
+    fun `sorted list is alphabetical`() {
+        val sorted = listOf(
+            makeArtist(2, "Shakira"),
+            makeArtist(1, "Carlos Vives"),
+            makeArtist(3, "Rubén Blades")
+        ).sortedBy { it.name }
         assertEquals("Carlos Vives", sorted[0].name)
         assertEquals("Rubén Blades", sorted[1].name)
         assertEquals("Shakira", sorted[2].name)
     }
 
-    // --- Helpers ---
+    @Test
+    fun `empty list has size zero`() {
+        assertEquals(0, emptyList<Artist>().size)
+    }
+
+    @Test
+    fun `empty list isEmpty is true`() {
+        assertTrue(emptyList<Artist>().isEmpty())
+    }
+
+    @Test
+    fun `non empty list isEmpty is false`() {
+        assertFalse(listOf(makeArtist(1, "Artista")).isEmpty())
+    }
+
+    @Test
+    fun `empty list triggers empty view logic`() {
+        val artists = emptyList<Artist>()
+        assertTrue(artists.isEmpty())
+        assertFalse(artists.isNotEmpty())
+    }
+
+    @Test
+    fun `non empty list triggers recycler visible logic`() {
+        val artists = listOf(makeArtist(1, "Artista"))
+        assertFalse(artists.isEmpty())
+        assertTrue(artists.isNotEmpty())
+    }
+
+    @Test
+    fun `empty view hidden on error regardless of list state`() {
+        val errorMsg = "Sin conexión a internet"
+        val artists = emptyList<Artist>()
+        val showEmptyView = artists.isEmpty() && errorMsg.isBlank()
+        assertFalse(showEmptyView)
+    }
+
+    @Test
+    fun `error message for no connection is not blank`() {
+        assertTrue("Sin conexión a internet".isNotBlank())
+    }
+
+    @Test
+    fun `error message for server error is not blank`() {
+        assertTrue("Error del servidor (500)".isNotBlank())
+    }
+
+    @Test
+    fun `error message for not found is not blank`() {
+        assertTrue("Recurso no encontrado (404)".isNotBlank())
+    }
+
+    @Test
+    fun `artist with empty birthDate is valid`() {
+        val artist = makeArtist(1, "Artista").copy(birthDate = "")
+        assertNotNull(artist)
+        assertEquals("", formatDate(artist.birthDate))
+    }
+
+    @Test
+    fun `artist with empty image is valid`() {
+        val artist = makeArtist(1, "Artista").copy(image = "")
+        assertNotNull(artist)
+        assertEquals("", artist.image)
+    }
 
     private fun makeArtist(id: Int, name: String) = Artist(
         artistId = id,
         name = name,
         image = "https://example.com/photo.jpg",
-        description = "Cantante y actor panameño",
+        description = "Cantante panameño",
         birthDate = "1948-07-16T05:00:00.000Z"
     )
 


### PR DESCRIPTION
## Cambios

- Nuevo caso de uso: **Listar artistas** (HU - pantalla de artistas)
- Arquitectura MVVM con patrón Repository, siguiendo la misma estructura de álbumes
- Endpoint: `GET /musicians`

## Archivos nuevos

| Capa | Archivo |
|------|---------|
| Model | `model/Artist.kt` |
| Network | `NetworkServiceAdapter` — método `getArtists()` |
| Repository | `repository/interfaces/ArtistRepository.kt`, `repository/impl/ArtistRepositoryImpl.kt` |
| ViewModel | `ui/artists/ArtistsViewModel.kt` |
| UI | `ui/artists/ArtistsFragment.kt`, `ui/artists/ArtistAdapter.kt` |
| Layouts | `fragment_artists.xml`, `item_artist.xml` |
| Nav | `nav_graph.xml` — fragmento `artistsFragment` registrado |

## Pruebas

- **Espresso (E2E):** `ArtistsListE2ETest` — 4 escenarios con `EspressoIdlingResource`
- **Unitarias:** `ArtistsViewModelTest` — 13 tests (modelo, formato de fecha, validaciones de lista)
- Build: `BUILD SUCCESSFUL` — 23/23 pruebas unitarias pasando

## Notas

- El detalle del artista queda para la rama de otro integrante del equipo
- Los items del listado no navegan por ahora (sin acción de click)